### PR TITLE
Add feature from ZX branch

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -11,7 +11,7 @@ jobs:
       VCPKG_ROOT: /usr/local/share/vcpkg
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: recursive
@@ -19,7 +19,7 @@ jobs:
       - uses: hendrikmuhs/ccache-action@v1.2
 
       - name: Restore Gradle Cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.gradle/
@@ -58,7 +58,7 @@ jobs:
         shell: bash
         run: echo "git_short_sha=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: vita3k-${{ env.git_short_sha }}-release.apk
           path: android/build/outputs/apk/release/android-release.apk

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,18 +2,18 @@ apply plugin: 'com.android.application'
 
 android {
 	namespace "org.vita3k.emulator"
-	compileSdk 34
-	ndkVersion "26.3.11579264"
+	compileSdk 35
+	ndkVersion "29.0.14206865"
 	buildFeatures {
 		buildConfig true
 	}
 
 	defaultConfig {
-		applicationId "org.vita3k.emulator"
-		minSdk 24
-		targetSdk 34
+		applicationId "org.vita3k.emulator.ikhoeyZX"
+		minSdk 28
+		targetSdk 35
 		versionCode 12
-		versionName "0.2.0-12"
+		versionName "0.2.0-12.5-ikhoeyZX"
 
 		externalNativeBuild {
 			cmake {
@@ -44,6 +44,7 @@ android {
 			externalNativeBuild {
 				cmake {
 					arguments "-DCMAKE_BUILD_TYPE=RelWithDebInfo"
+					arguments "-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON"
 				}
 			}
 			minifyEnabled false
@@ -58,12 +59,13 @@ android {
 			externalNativeBuild {
 				cmake {
 					arguments "-DCMAKE_BUILD_TYPE=Release"
+					arguments "-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON"
 				}
 			}
 			minifyEnabled true
 			shrinkResources true
-			proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
 			signingConfig = signingConfigs.ci
+			proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
 		}
 	}
 
@@ -79,7 +81,7 @@ android {
 	externalNativeBuild {
 		cmake {
 			path '../CMakeLists.txt'
-			version '3.22.1+'
+			version '3.31.6+'
 		} 
 	}
 
@@ -98,11 +100,12 @@ android {
 }
 
 dependencies {
-	implementation 'androidx.appcompat:appcompat:1.6.1'
-	implementation "androidx.core:core:1.12.0"
-	implementation 'androidx.core:core-google-shortcuts:1.1.0'
-	implementation 'com.google.android.material:material:1.11.0'
-	implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
+	implementation 'androidx.appcompat:appcompat:1.7.0'
+	implementation "androidx.core:core:1.16.0-alpha02"
+	implementation 'androidx.core:core-google-shortcuts:1.2.0-alpha01'
+	implementation 'com.google.android.material:material:1.13.0-alpha11'
+	implementation 'androidx.constraintlayout:constraintlayout:2.2.1'
 	implementation 'com.getkeepsafe.relinker:relinker:1.4.5'
-	implementation 'com.jakewharton:process-phoenix:2.1.2'
+	implementation 'com.jakewharton:process-phoenix:3.0.0'
+	implementation 'androidx.documentfile:documentfile:1.1.0-alpha01'
 }

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -83,7 +83,7 @@
     <application android:label="@string/app_name"
         android:icon="@mipmap/ic_launcher"
         android:allowBackup="true"
-        android:theme="@android:style/Theme.NoTitleBar.Fullscreen"
+        android:theme="@style/AppTheme"
         android:hardwareAccelerated="true"
         android:appCategory="game"
         android:isGame="true"
@@ -94,13 +94,16 @@
         <!-- Example of setting SDL hints from AndroidManifest.xml:
         <meta-data android:name="SDL_ENV.SDL_ACCELEROMETER_AS_JOYSTICK" android:value="0"/>
          -->
-
+        
+        <meta-data android:name="android.game_mode_config"
+             android:resource="@xml/game_mode_config" />
+        
         <activity android:name="Emulator"
             android:alwaysRetainTaskState="true"
             android:launchMode="singleInstance"
             android:configChanges="layoutDirection|locale|orientation|uiMode|screenLayout|screenSize|smallestScreenSize|keyboard|keyboardHidden|navigation"
             android:preferMinimalPostProcessing="true"
-            android:theme="@style/Theme.Design.NoActionBar"
+            android:theme="@style/AppTheme"
             android:exported="true"
             tools:targetApi="r">
 

--- a/android/src/main/java/org/libsdl/app/HIDDeviceManager.java
+++ b/android/src/main/java/org/libsdl/app/HIDDeviceManager.java
@@ -193,7 +193,11 @@ public class HIDDeviceManager {
         filter.addAction(UsbManager.ACTION_USB_DEVICE_ATTACHED);
         filter.addAction(UsbManager.ACTION_USB_DEVICE_DETACHED);
         filter.addAction(HIDDeviceManager.ACTION_USB_PERMISSION);
-        mContext.registerReceiver(mUsbBroadcast, filter);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            mContext.registerReceiver(mUsbBroadcast, filter, Context.RECEIVER_EXPORTED);
+        } else {
+            mContext.registerReceiver(mUsbBroadcast, filter);
+        }
 
         for (UsbDevice usbDevice : mUsbManager.getDeviceList().values()) {
             handleUsbDeviceAttached(usbDevice);
@@ -227,6 +231,7 @@ public class HIDDeviceManager {
         final int XB360_IFACE_PROTOCOL = 1; // Wired
         final int XB360W_IFACE_PROTOCOL = 129; // Wireless
         final int[] SUPPORTED_VENDORS = {
+            0x03f0, // HP
             0x0079, // GPD Win 2
             0x044f, // Thrustmaster
             0x045e, // Microsoft
@@ -235,6 +240,7 @@ public class HIDDeviceManager {
             0x06a3, // Saitek
             0x0738, // Mad Catz
             0x07ff, // Mad Catz
+            0x0b05, // ASUS
             0x0e6f, // PDP
             0x0f0d, // Hori
             0x1038, // SteelSeries
@@ -253,6 +259,7 @@ public class HIDDeviceManager {
             0x2c22, // Qanba
             0x2dc8, // 8BitDo
             0x9886, // ASTRO Gaming
+            0x3537, // GameSir
         };
 
         if (usbInterface.getInterfaceClass() == UsbConstants.USB_CLASS_VENDOR_SPEC &&
@@ -363,11 +370,6 @@ public class HIDDeviceManager {
             return;
         }
 
-        if (!mContext.getPackageManager().hasSystemFeature(PackageManager.FEATURE_BLUETOOTH_LE) || (Build.VERSION.SDK_INT < 18 /* Android 4.3 (JELLY_BEAN_MR2) */)) {
-            Log.d(TAG, "Couldn't initialize Bluetooth, this version of Android does not support Bluetooth LE");
-            return;
-        }
-
         // Find bonded bluetooth controllers and create SteamControllers for them
         mBluetoothManager = (BluetoothManager)mContext.getSystemService(Context.BLUETOOTH_SERVICE);
         if (mBluetoothManager == null) {
@@ -395,7 +397,11 @@ public class HIDDeviceManager {
         IntentFilter filter = new IntentFilter();
         filter.addAction(BluetoothDevice.ACTION_ACL_CONNECTED);
         filter.addAction(BluetoothDevice.ACTION_ACL_DISCONNECTED);
-        mContext.registerReceiver(mBluetoothBroadcast, filter);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            mContext.registerReceiver(mBluetoothBroadcast, filter, Context.RECEIVER_EXPORTED);
+        } else {
+            mContext.registerReceiver(mBluetoothBroadcast, filter);
+        }
 
         if (mIsChromebook) {
             mHandler = new Handler(Looper.getMainLooper());
@@ -582,7 +588,14 @@ public class HIDDeviceManager {
                 } else {
                     flags = 0;
                 }
-                mUsbManager.requestPermission(usbDevice, PendingIntent.getBroadcast(mContext, 0, new Intent(HIDDeviceManager.ACTION_USB_PERMISSION), flags));
+
+                if (Build.VERSION.SDK_INT >= 33 /* Android 14.0 (U) */) {
+                    Intent intent = new Intent(HIDDeviceManager.ACTION_USB_PERMISSION);
+                    intent.setPackage(mContext.getPackageName());
+                    mUsbManager.requestPermission(usbDevice, PendingIntent.getBroadcast(mContext, 0, intent, flags));
+                } else {
+                    mUsbManager.requestPermission(usbDevice, PendingIntent.getBroadcast(mContext, 0, new Intent(HIDDeviceManager.ACTION_USB_PERMISSION), flags));
+                }
             } catch (Exception e) {
                 Log.v(TAG, "Couldn't request permission for USB device " + usbDevice);
                 HIDDeviceOpenResult(deviceID, false);

--- a/android/src/main/java/org/libsdl/app/SDL.java
+++ b/android/src/main/java/org/libsdl/app/SDL.java
@@ -38,27 +38,31 @@ public class SDL {
     }
 
     public static void loadLibrary(String libraryName) throws UnsatisfiedLinkError, SecurityException, NullPointerException {
+        loadLibrary(libraryName, mContext);
+    }
+
+    public static void loadLibrary(String libraryName, Context context) throws UnsatisfiedLinkError, SecurityException, NullPointerException {
 
         if (libraryName == null) {
             throw new NullPointerException("No library name provided.");
         }
 
         try {
-            // Let's see if we have ReLinker available in the project.  This is necessary for 
-            // some projects that have huge numbers of local libraries bundled, and thus may 
+            // Let's see if we have ReLinker available in the project.  This is necessary for
+            // some projects that have huge numbers of local libraries bundled, and thus may
             // trip a bug in Android's native library loader which ReLinker works around.  (If
             // loadLibrary works properly, ReLinker will simply use the normal Android method
             // internally.)
             //
-            // To use ReLinker, just add it as a dependency.  For more information, see 
+            // To use ReLinker, just add it as a dependency.  For more information, see
             // https://github.com/KeepSafe/ReLinker for ReLinker's repository.
             //
-            Class<?> relinkClass = mContext.getClassLoader().loadClass("com.getkeepsafe.relinker.ReLinker");
-            Class<?> relinkListenerClass = mContext.getClassLoader().loadClass("com.getkeepsafe.relinker.ReLinker$LoadListener");
-            Class<?> contextClass = mContext.getClassLoader().loadClass("android.content.Context");
-            Class<?> stringClass = mContext.getClassLoader().loadClass("java.lang.String");
+            Class<?> relinkClass = context.getClassLoader().loadClass("com.getkeepsafe.relinker.ReLinker");
+            Class<?> relinkListenerClass = context.getClassLoader().loadClass("com.getkeepsafe.relinker.ReLinker$LoadListener");
+            Class<?> contextClass = context.getClassLoader().loadClass("android.content.Context");
+            Class<?> stringClass = context.getClassLoader().loadClass("java.lang.String");
 
-            // Get a 'force' instance of the ReLinker, so we can ensure libraries are reinstalled if 
+            // Get a 'force' instance of the ReLinker, so we can ensure libraries are reinstalled if
             // they've changed during updates.
             Method forceMethod = relinkClass.getDeclaredMethod("force");
             Object relinkInstance = forceMethod.invoke(null);
@@ -66,7 +70,7 @@ public class SDL {
 
             // Actually load the library!
             Method loadMethod = relinkInstanceClass.getDeclaredMethod("loadLibrary", contextClass, stringClass, stringClass, relinkListenerClass);
-            loadMethod.invoke(relinkInstance, mContext, libraryName, null, null);
+            loadMethod.invoke(relinkInstance, context, libraryName, null, null);
         }
         catch (final Throwable e) {
             // Fall back

--- a/android/src/main/java/org/libsdl/app/SDLActivity.java
+++ b/android/src/main/java/org/libsdl/app/SDLActivity.java
@@ -285,7 +285,7 @@ public class SDLActivity extends Activity implements View.OnSystemUiVisibilityCh
     // Load the .so
     public void loadLibraries() {
        for (String lib : getLibraries()) {
-          SDL.loadLibrary(lib);
+          SDL.loadLibrary(lib, this);
        }
     }
 
@@ -1001,8 +1001,8 @@ public class SDLActivity extends Activity implements View.OnSystemUiVisibilityCh
         /* No valid hint, nothing is explicitly allowed */
         if (!is_portrait_allowed && !is_landscape_allowed) {
             if (resizable) {
-                /* All orientations are allowed */
-                req = ActivityInfo.SCREEN_ORIENTATION_FULL_SENSOR;
+                /* All orientations are allowed, respecting user orientation lock setting */
+                req = ActivityInfo.SCREEN_ORIENTATION_FULL_USER;
             } else {
                 /* Fixed window and nothing specified. Get orientation from w/h of created window */
                 req = (w > h ? ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE : ActivityInfo.SCREEN_ORIENTATION_SENSOR_PORTRAIT);
@@ -1011,8 +1011,8 @@ public class SDLActivity extends Activity implements View.OnSystemUiVisibilityCh
             /* At least one orientation is allowed */
             if (resizable) {
                 if (is_portrait_allowed && is_landscape_allowed) {
-                    /* hint allows both landscape and portrait, promote to full sensor */
-                    req = ActivityInfo.SCREEN_ORIENTATION_FULL_SENSOR;
+                    /* hint allows both landscape and portrait, promote to full user */
+                    req = ActivityInfo.SCREEN_ORIENTATION_FULL_USER;
                 } else {
                     /* Use the only one allowed "orientation" */
                     req = (is_landscape_allowed ? orientation_landscape : orientation_portrait);
@@ -2120,4 +2120,3 @@ class SDLClipboardHandler implements
         SDLActivity.onNativeClipboardChanged();
     }
 }
-

--- a/android/src/main/java/org/libsdl/app/SDLActivity.java
+++ b/android/src/main/java/org/libsdl/app/SDLActivity.java
@@ -59,10 +59,10 @@ import java.util.Locale;
 */
 public class SDLActivity extends Activity implements View.OnSystemUiVisibilityChangeListener {
     private static final String TAG = "SDL";
-    private static final int SDL_MAJOR_VERSION = 2;
+/*    private static final int SDL_MAJOR_VERSION = 2;
     private static final int SDL_MINOR_VERSION = 28;
     private static final int SDL_MICRO_VERSION = 3;
-/*
+
     // Display InputType.SOURCE/CLASS of events and devices
     //
     // SDLActivity.debugSource(device.getSources(), "device[" + device.getName() + "]");
@@ -351,6 +351,7 @@ public class SDLActivity extends Activity implements View.OnSystemUiVisibilityCh
             errorMsgBrokenLib = e.getMessage();
         }
 
+/* 
         if (!mBrokenLibraries) {
             String expected_version = String.valueOf(SDL_MAJOR_VERSION) + "." +
                                       String.valueOf(SDL_MINOR_VERSION) + "." +
@@ -361,6 +362,7 @@ public class SDLActivity extends Activity implements View.OnSystemUiVisibilityCh
                 errorMsgBrokenLib = "SDL C/Java version mismatch (expected " + expected_version + ", got " + version + ")";
             }
         }
+*/
 
         if (mBrokenLibraries) {
             mSingleton = this;

--- a/android/src/main/java/org/libsdl/app/SDLControllerManager.java
+++ b/android/src/main/java/org/libsdl/app/SDLControllerManager.java
@@ -546,13 +546,15 @@ class SDLHapticHandler {
             if (haptic == null) {
                 InputDevice device = InputDevice.getDevice(deviceIds[i]);
                 Vibrator vib = device.getVibrator();
-                if (vib.hasVibrator()) {
-                    haptic = new SDLHaptic();
-                    haptic.device_id = deviceIds[i];
-                    haptic.name = device.getName();
-                    haptic.vib = vib;
-                    mHaptics.add(haptic);
-                    SDLControllerManager.nativeAddHaptic(haptic.device_id, haptic.name);
+                if (vib != null) {
+                    if (vib.hasVibrator()) {
+                        haptic = new SDLHaptic();
+                        haptic.device_id = deviceIds[i];
+                        haptic.name = device.getName();
+                        haptic.vib = vib;
+                        mHaptics.add(haptic);
+                        SDLControllerManager.nativeAddHaptic(haptic.device_id, haptic.name);
+                    }
                 }
             }
         }
@@ -851,4 +853,4 @@ class SDLGenericMotionListener_API26 extends SDLGenericMotionListener_API24 {
         // Relative mouse in capture mode will only have relative for X/Y
         return event.getY(0);
     }
-}
+                    }

--- a/android/src/main/java/org/vita3k/emulator/Emulator.java
+++ b/android/src/main/java/org/vita3k/emulator/Emulator.java
@@ -270,12 +270,12 @@ public class Emulator extends SDLActivity
     }
 
     @Keep
-    public boolean createShortcut(String game_id, String game_name){
+    public boolean createShortcut(String game_path, String game_id, String game_name){
         if(!ShortcutManagerCompat.isRequestPinShortcutSupported(getContext()))
             return false;
 
         // first look at the icon, its location should always be the same
-        File src_icon = new File(getExternalFilesDir(null), "vita/ux0/app/" + game_id + "/sce_sys/icon0.png");
+        File src_icon = new File(game_path + "/ux0/app/" + game_id + "/sce_sys/icon0.png");
         Bitmap icon;
         if(src_icon.exists())
             icon = BitmapFactory.decodeFile(src_icon.getPath());

--- a/android/src/main/java/org/vita3k/emulator/Emulator.java
+++ b/android/src/main/java/org/vita3k/emulator/Emulator.java
@@ -260,8 +260,8 @@ public class Emulator extends SDLActivity
     }
 
     @Keep
-    public void setControllerOverlayScale(float scale){
-        getmOverlay().setScale(scale);
+    public void setControllerOverlayScale(float scale, float scale_joystick){
+        getmOverlay().setScale(scale, scale_joystick);
     }
 
     @Keep

--- a/android/src/main/java/org/vita3k/emulator/overlay/InputOverlay.java
+++ b/android/src/main/java/org/vita3k/emulator/overlay/InputOverlay.java
@@ -59,6 +59,7 @@ public final class InputOverlay extends SurfaceView implements OnTouchListener
   private InputOverlayDrawableDpad mDpadBeingConfigured;
   private InputOverlayDrawableJoystick mJoystickBeingConfigured;
   private static float mGlobalScale = 1.0f;
+  private static float mJoyScale = 1.0f;
   private static int mGlobalOpacity = 100;
 
   private Timer mTimer;
@@ -604,9 +605,10 @@ public final class InputOverlay extends SurfaceView implements OnTouchListener
     refreshControls();
   }
 
-  public void setScale(float scale){
-    if(scale != mGlobalScale){
+  public void setScale(float scale, float scale_joystick){
+    if(scale != mGlobalScale || scale_joystick != mJoyScale){
       mGlobalScale = scale;
+      mJoyScale = scale_joystick;
       refreshControls();
     }
   }
@@ -819,7 +821,7 @@ public final class InputOverlay extends SurfaceView implements OnTouchListener
 
     // Decide scale based on user preference
     float scale = 0.275f;
-    scale *= mGlobalScale;
+    scale *= mJoyScale;
 
     // Initialize the InputOverlayDrawableJoystick.
     final Bitmap bitmapOuter =

--- a/android/src/main/res/values/styles.xml
+++ b/android/src/main/res/values/styles.xml
@@ -1,6 +1,12 @@
 <resources>
 
-    <style name="AppTheme" parent="android:Theme.Holo.Light.DarkActionBar">
-    </style>
+<style name="AppTheme" parent="android:Theme.NoTitleBar.Fullscreen">
+  <item name="windowActionBar">false</item>
+  <item name="windowNoTitle">true</item>
+  <item name="android:windowFullscreen">true</item>
+  <item name="android:windowLayoutInDisplayCutoutMode">
+    shortEdges <!-- default, shortEdges, or never -->
+  </item>
+</style>
 
 </resources>

--- a/android/src/main/res/xml/game_mode_config.xml
+++ b/android/src/main/res/xml/game_mode_config.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<game-mode-config
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:supportsBatteryGameMode="true"
+    android:supportsPerformanceGameMode="true"
+/>

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -94,6 +94,10 @@ target_include_directories(miniz PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/miniz")
 
 add_library(sdl2 INTERFACE)
 if(ANDROID)
+  if(NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/sdl/android/lib/${ANDROID_ABI}/libSDL2.a")
+    execute_process(COMMAND ${CMAKE_COMMAND} -E tar xf "${CMAKE_CURRENT_SOURCE_DIR}/sdl/android/libSDL2.zip"
+      WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/sdl/android/")
+  endif()
 	target_include_directories(sdl2 INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/sdl/android/include")
 	target_link_libraries(sdl2 INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/sdl/android/lib/${ANDROID_ABI}/libSDL2.a")
 	target_link_libraries(sdl2 INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/sdl/android/lib/${ANDROID_ABI}/libcpufeatures.a")

--- a/vita3k/app/src/app_init.cpp
+++ b/vita3k/app/src/app_init.cpp
@@ -136,8 +136,16 @@ static bool load_custom_driver(const std::string &driver_name) {
     load_library_parameter.handle = vulkan_handle;
 
     if (SDL_Vulkan_LoadLibrary(reinterpret_cast<const char *>(&load_library_parameter)) < 0) {
-        LOG_ERROR("Could not load custom diver, error {}", SDL_GetError());
-        return false;
+        LOG_ERROR("Could not load custom driver, error {}", SDL_GetError());
+    	app::error_dialog("Could not load custom driver.\napp will use system driver instead");
+        vulkan_handle = dlopen("libvulkan.so", RTLD_NOW | RTLD_LOCAL);
+    	if (vulkan_handle == nullptr)
+    	{
+    	   char *error = dlerror();
+    	   LOG_WARN( "Failed to load system Vulkan driver: %s", error ? error : "");
+    	   app::error_dialog("Could not load system vulkan driver\napp will exit.");
+    	   return false;
+    	}
     }
 
     return true;

--- a/vita3k/config/include/config/config.h
+++ b/vita3k/config/include/config/config.h
@@ -53,6 +53,7 @@ enum PerfomanceOverleyPosition {
     code(bool, "log-uniforms", false, log_uniforms)                                                     \
     code(bool, "log-compat-warn", false, log_compat_warn)                                               \
     code(bool, "validation-layer", true, validation_layer)                                              \
+    code(bool, "debug-menu", false, debug_menu)                                                         \
     code(bool, "pstv-mode", false, pstv_mode)                                                           \
     code(bool, "show-mode", false, show_mode)                                                           \
     code(bool, "demo-mode", false, demo_mode)                                                           \

--- a/vita3k/config/include/config/config.h
+++ b/vita3k/config/include/config/config.h
@@ -111,6 +111,7 @@ enum PerfomanceOverleyPosition {
     code(bool, "overlay-show-touch-switch", false, overlay_show_touch_switch)                           \
     code(float, "overlay-scale", 1.0f, overlay_scale)                                                   \
     code(int, "overlay-opacity", 100, overlay_opacity)                                                  \
+    code(float, "overlay-scale-joystick", 1.0f, overlay_scale_joystick)                                 \
     code(int, "keyboard-button-select", 229, keyboard_button_select)                                    \
     code(int, "keyboard-button-start", 40, keyboard_button_start)                                       \
     code(int, "keyboard-button-up", 82, keyboard_button_up)                                             \

--- a/vita3k/config/include/config/config.h
+++ b/vita3k/config/include/config/config.h
@@ -112,6 +112,8 @@ enum PerfomanceOverleyPosition {
     code(float, "overlay-scale", 1.0f, overlay_scale)                                                   \
     code(int, "overlay-opacity", 100, overlay_opacity)                                                  \
     code(float, "overlay-scale-joystick", 1.0f, overlay_scale_joystick)                                 \
+    code(bool, "disable-motion", false, disable_motion)                                                 \
+    code(bool, "invert-gyro", false, invert_gyro)
     code(int, "keyboard-button-select", 229, keyboard_button_select)                                    \
     code(int, "keyboard-button-start", 40, keyboard_button_start)                                       \
     code(int, "keyboard-button-up", 82, keyboard_button_up)                                             \

--- a/vita3k/config/include/config/config.h
+++ b/vita3k/config/include/config/config.h
@@ -113,7 +113,7 @@ enum PerfomanceOverleyPosition {
     code(int, "overlay-opacity", 100, overlay_opacity)                                                  \
     code(float, "overlay-scale-joystick", 1.0f, overlay_scale_joystick)                                 \
     code(bool, "disable-motion", false, disable_motion)                                                 \
-    code(bool, "invert-gyro", false, invert_gyro)
+    code(bool, "invert-gyro", false, invert_gyro)                                                       \
     code(int, "keyboard-button-select", 229, keyboard_button_select)                                    \
     code(int, "keyboard-button-start", 40, keyboard_button_start)                                       \
     code(int, "keyboard-button-up", 82, keyboard_button_up)                                             \

--- a/vita3k/ctrl/include/ctrl/state.h
+++ b/vita3k/ctrl/include/ctrl/state.h
@@ -58,6 +58,7 @@ struct CtrlState {
     ControllerList controllers;
     int controllers_num = 0;
     bool has_motion_support = false;
+    bool controllers_has_motion_support[SCE_CTRL_MAX_WIRELESS_NUM] = { false, false, false, false };
     const char *controllers_name[SCE_CTRL_MAX_WIRELESS_NUM] = {};
     bool free_ports[SCE_CTRL_MAX_WIRELESS_NUM] = { true, true, true, true };
     SceCtrlPadInputMode input_mode = SCE_CTRL_MODE_DIGITAL;

--- a/vita3k/ctrl/src/ctrl.cpp
+++ b/vita3k/ctrl/src/ctrl.cpp
@@ -99,16 +99,15 @@ void refresh_controllers(CtrlState &state, EmuEnvState &emuenv) {
     bool found_gyro = false;
     bool found_accel = false;
     for (ControllerList::iterator controller = state.controllers.begin(); controller != state.controllers.end();) {
-        if (SDL_GameControllerGetAttached(controller->second.controller.get())) {
-            found_accel |= controller->second.has_accel;
-            found_gyro |= controller->second.has_gyro;
-
-            ++controller;
-        } else {
-            state.free_ports[controller->second.port - 1] = true;
-            controller = state.controllers.erase(controller);
-            state.controllers_num--;
-        }
+            if (SDL_GameControllerGetAttached(controller->second.controller.get())) {
+                found_accel |= controller->second.has_accel;
+                found_gyro |= controller->second.has_gyro;
+                ++controller;
+            } else {
+                state.free_ports[controller->second.port - 1] = true;
+                controller = state.controllers.erase(controller);
+                state.controllers_num--;
+            }
     }
 
     // Add new controllers
@@ -119,7 +118,6 @@ void refresh_controllers(CtrlState &state, EmuEnvState &emuenv) {
         }
         if (SDL_IsGameController(joystick_index)) {
             const SDL_JoystickGUID guid = SDL_JoystickGetDeviceGUID(joystick_index);
-
 #ifdef ANDROID
             // for whatever reasons, fingerprint sensors are detected as controllers, filter them out
             const char *controller_name = SDL_GameControllerNameForIndex(joystick_index);
@@ -128,19 +126,31 @@ void refresh_controllers(CtrlState &state, EmuEnvState &emuenv) {
                 || std::string_view(controller_name).starts_with("gf_")))
                 continue;
 #endif
-
             if (!state.controllers.contains(guid)) {
                 Controller new_controller;
                 const GameControllerPtr controller(SDL_GameControllerOpen(joystick_index), SDL_GameControllerClose);
                 new_controller.controller = controller;
                 new_controller.port = reserve_port(state);
 
-                new_controller.has_gyro = SDL_GameControllerHasSensor(controller.get(), SDL_SENSOR_GYRO);
-                if (new_controller.has_gyro)
-                    SDL_GameControllerSetSensorEnabled(controller.get(), SDL_SENSOR_GYRO, SDL_TRUE);
                 new_controller.has_accel = SDL_GameControllerHasSensor(controller.get(), SDL_SENSOR_ACCEL);
-                if (new_controller.has_accel)
-                    SDL_GameControllerSetSensorEnabled(controller.get(), SDL_SENSOR_ACCEL, SDL_TRUE);
+                new_controller.has_gyro = SDL_GameControllerHasSensor(controller.get(), SDL_SENSOR_GYRO);
+
+                if(!emuenv.cfg.disable_motion){
+                   if (new_controller.has_accel)
+                       SDL_GameControllerSetSensorEnabled(controller.get(), SDL_SENSOR_ACCEL, SDL_TRUE);
+                   if (new_controller.has_gyro)
+                       SDL_GameControllerSetSensorEnabled(controller.get(), SDL_SENSOR_GYRO, SDL_TRUE);
+                    LOG_INFO("Accel and gyro sensor enabled");
+                }else{
+                   if (new_controller.has_accel)
+                       SDL_GameControllerSetSensorEnabled(controller.get(), SDL_SENSOR_ACCEL, SDL_FALSE);
+                   if (new_controller.has_gyro)
+                       SDL_GameControllerSetSensorEnabled(controller.get(), SDL_SENSOR_GYRO, SDL_FALSE);
+                    LOG_INFO("Accel and gyro sensor disabled");
+                }
+
+               found_gyro |= new_controller.has_gyro;
+               found_accel |= new_controller.has_accel;
 
                 new_controller.has_led = SDL_GameControllerHasLED(controller.get());
                 if (new_controller.has_led) {
@@ -150,12 +160,10 @@ void refresh_controllers(CtrlState &state, EmuEnvState &emuenv) {
                         SDL_GameControllerSetLED(controller.get(), color[0], color[1], color[2]);
                     }
                 }
-
-                found_gyro |= new_controller.has_gyro;
-                found_accel |= new_controller.has_accel;
-
+                
                 state.controllers.emplace(guid, new_controller);
                 state.controllers_name[joystick_index] = SDL_GameControllerNameForIndex(joystick_index);
+                state.controllers_has_motion_support[joystick_index] = found_gyro && found_accel;
                 state.controllers_num++;
             }
         }

--- a/vita3k/gui/include/gui/functions.h
+++ b/vita3k/gui/include/gui/functions.h
@@ -111,7 +111,7 @@ void update_notice_info(GuiState &gui, EmuEnvState &emuenv, const std::string &t
 void update_time_app_used(GuiState &gui, EmuEnvState &emuenv, const std::string &app);
 void save_notice_list(EmuEnvState &emuenv);
 void set_controller_overlay_state(int overlay_mask, bool edit = false, bool reset = false);
-void set_controller_overlay_scale(float scale);
+void set_controller_overlay_scale(float scale, float joystick);
 void set_controller_overlay_opacity(int opacity);
 int get_overlay_display_mask(const Config &cfg);
 

--- a/vita3k/gui/src/about_dialog.cpp
+++ b/vita3k/gui/src/about_dialog.cpp
@@ -57,12 +57,13 @@ void draw_about_dialog(GuiState &gui, EmuEnvState &emuenv) {
     const ImVec2 display_size(emuenv.viewport_size.x, emuenv.viewport_size.y);
     const ImVec2 RES_SCALE(display_size.x / emuenv.res_width_dpi_scale, display_size.y / emuenv.res_height_dpi_scale);
     const ImVec2 SCALE(RES_SCALE.x * emuenv.dpi_scale, RES_SCALE.y * emuenv.dpi_scale);
+    const ImVec2 CENTER_POS = ImGui::GetMainViewport()->GetCenter();
     static const auto BUTTON_SIZE = ImVec2(120.f * emuenv.dpi_scale, 0.f);
 
     auto &lang = gui.lang.about;
     auto &common = emuenv.common_dialog.lang.common;
 
-    ImGui::SetNextWindowPos(ImVec2(display_size.x / 2.f, display_size.y / 2.f), ImGuiCond_Always, ImVec2(0.5f, 0.5f));
+    ImGui::SetNextWindowPos(CENTER_POS, ImGuiCond_Always, ImVec2(0.5f, 0.5f));
     ImGui::Begin("##about", &gui.help_menu.about_dialog, ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoSavedSettings | ImGuiWindowFlags_AlwaysAutoResize);
     ImGui::SetWindowFontScale(RES_SCALE.x);
     auto title_str = lang["title"].c_str();

--- a/vita3k/gui/src/app_context_menu.cpp
+++ b/vita3k/gui/src/app_context_menu.cpp
@@ -39,7 +39,7 @@
 #ifdef ANDROID
 #include <jni.h>
 
-static void create_shortcut(const std::string_view game_id, const std::string_view game_name){
+static void create_shortcut(const std::string_view game_path, const std::string_view game_id, const std::string_view game_name){
     // retrieve the JNI environment.
     JNIEnv *env = reinterpret_cast<JNIEnv *>(SDL_AndroidGetJNIEnv());
 
@@ -50,11 +50,12 @@ static void create_shortcut(const std::string_view game_id, const std::string_vi
     jclass clazz(env->GetObjectClass(activity));
 
     // find the identifier of the method to call
-    jmethodID method_id = env->GetMethodID(clazz, "createShortcut", "(Ljava/lang/String;Ljava/lang/String;)Z");
+    jmethodID method_id = env->GetMethodID(clazz, "createShortcut", "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Z");
+    jstring j_game_path = env->NewStringUTF(game_path.data());
     jstring j_game_id = env->NewStringUTF(game_id.data());
     jstring j_game_name = env->NewStringUTF(game_name.data());
 
-    jboolean result = env->CallBooleanMethod(activity, method_id, j_game_id, j_game_name);
+    jboolean result = env->CallBooleanMethod(activity, method_id, j_game_path, j_game_id, j_game_name);
 
     // clean up the local references.
     env->DeleteLocalRef(j_game_name);
@@ -518,7 +519,7 @@ void draw_app_context_menu(GuiState &gui, EmuEnvState &emuenv, const std::string
             }
 #else
             if(ImGui::MenuItem("Create Shortcut")){
-                create_shortcut(title_id, APP_INDEX->title);
+                create_shortcut(emuenv.pref_path.string(), title_id, APP_INDEX->title);
             }
 #endif
 

--- a/vita3k/gui/src/controllers_dialog.cpp
+++ b/vita3k/gui/src/controllers_dialog.cpp
@@ -366,6 +366,9 @@ void draw_controllers_dialog(GuiState &gui, EmuEnvState &emuenv) {
                     if (ImGui::Button(common["close"].c_str(), BUTTON_SIZE))
                         rebinds_is_open = false;
 
+#ifdef ANDROID
+                    ImGui::ScrollWhenDragging(); // because only in Android was hard to press scroll slider
+#endif
                     ImGui::End();
                 }
             }

--- a/vita3k/gui/src/controllers_dialog.cpp
+++ b/vita3k/gui/src/controllers_dialog.cpp
@@ -20,6 +20,7 @@
 #include <config/functions.h>
 #include <config/state.h>
 #include <ctrl/state.h>
+#include <dialog/state.h>
 #include <emuenv/state.h>
 #include <gui/functions.h>
 #include <motion/state.h>
@@ -170,6 +171,39 @@ static void add_bind_to_table(GuiState &gui, EmuEnvState &emuenv, const SDL_Game
     ImGui::PopID();
 }
 
+void swap_controller_ports(CtrlState &state, int source_port, int dest_port) {
+    // Check if the ports are valid
+    if (source_port < 1 || source_port > SCE_CTRL_MAX_WIRELESS_NUM || dest_port < 1 || dest_port > SCE_CTRL_MAX_WIRELESS_NUM) {
+        LOG_ERROR("Ports are not valid.");
+        return;
+    }
+
+    // Find the controllers corresponding to the source and destination ports
+    auto source_controller_it = std::find_if(state.controllers.begin(), state.controllers.end(),
+        [source_port](const auto &pair) { return pair.second.port == source_port; });
+    auto dest_controller_it = std::find_if(state.controllers.begin(), state.controllers.end(),
+        [dest_port](const auto &pair) { return pair.second.port == dest_port; });
+
+    // Check that both controllers exist
+    if (source_controller_it == state.controllers.end() || dest_controller_it == state.controllers.end()) {
+        LOG_ERROR("Unable to find one or more controllers on the specified ports.");
+        return;
+    }
+
+    LOG_INFO("Controller on source port {} {} swapped with controller on destination port {} {}", source_port, state.controllers_name[source_port - 1], dest_port, state.controllers_name[dest_port - 1]);
+
+    // Swap controllers info and player index
+    SDL_GameControllerSetPlayerIndex(source_controller_it->second.controller.get(), dest_port - 1);
+    std::swap(source_controller_it->second.port, dest_controller_it->second.port);
+    std::swap(source_controller_it->second.has_accel, dest_controller_it->second.has_accel);
+    std::swap(source_controller_it->second.has_gyro, dest_controller_it->second.has_gyro);
+    std::swap(source_controller_it->second.has_led, dest_controller_it->second.has_led);
+
+    // Swap controller names
+    std::swap(state.controllers_name[source_port - 1], state.controllers_name[dest_port - 1]);
+    std::swap(state.controllers_has_motion_support[source_port - 1], state.controllers_has_motion_support[dest_port - 1]);
+}
+
 void draw_controllers_dialog(GuiState &gui, EmuEnvState &emuenv) {
     const ImVec2 VIEWPORT_POS(emuenv.viewport_pos.x, emuenv.viewport_pos.y);
     const ImVec2 VIEWPORT_SIZE(emuenv.viewport_size.x, emuenv.viewport_size.y);
@@ -182,8 +216,6 @@ void draw_controllers_dialog(GuiState &gui, EmuEnvState &emuenv) {
 
     const auto has_controllers = ctrl.controllers_num > 0;
 
-    if (has_controllers)
-        ImGui::SetNextWindowSize(ImVec2(VIEWPORT_SIZE.x / 2.5f, 0), ImGuiCond_Always);
     ImGui::SetNextWindowPos(ImVec2(VIEWPORT_POS.x + (VIEWPORT_SIZE.x / 2.f), VIEWPORT_POS.y + (VIEWPORT_SIZE.y / 2.f)), ImGuiCond_Always, ImVec2(0.5f, 0.5f));
     ImGui::Begin("##controllers", &gui.controls_menu.controllers_dialog, ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoSavedSettings);
     ImGui::SetWindowFontScale(RES_SCALE.x);
@@ -194,24 +226,35 @@ void draw_controllers_dialog(GuiState &gui, EmuEnvState &emuenv) {
     ImGui::Separator();
 
     if (has_controllers) {
-        const auto connected_str = fmt::format(fmt::runtime(lang["connected"].c_str()), ctrl.controllers_num);
+        const auto connected_str = fmt::format(fmt::runtime(lang["connected"]), ctrl.controllers_num);
         ImGui::TextColored(GUI_COLOR_TEXT_MENUBAR, "%s", connected_str.c_str());
         ImGui::Spacing();
         ImGui::Separator();
         ImGui::Spacing();
-        if (ImGui::BeginTable("main", 2, ImGuiTableFlags_NoSavedSettings | ImGuiTableFlags_BordersInnerV)) {
+        if (ImGui::BeginTable("main", 3, ImGuiTableFlags_NoSavedSettings | ImGuiTableFlags_BordersInnerV)) {
             ImGui::TableSetupColumn("num");
             ImGui::TableSetupColumn("name");
+            ImGui::TableSetupColumn("motion");
             ImGui::TableNextRow();
             ImGui::TableSetColumnIndex(0);
             ImGui::TextColored(GUI_COLOR_TEXT_TITLE, "%s", lang["num"].c_str());
             ImGui::TableSetColumnIndex(1);
             ImGui::TextColored(GUI_COLOR_TEXT_TITLE, "%s", lang["name"].c_str());
             ImGui::Spacing();
+            ImGui::TableSetColumnIndex(2);
+            ImGui::TextColored(GUI_COLOR_TEXT_TITLE, "%s", lang["support_motion"].c_str());
+            const char *port_names[] = { "1", "2", "3", "4" };
+            static int selected_port = -1;
             for (auto i = 0; i < ctrl.controllers_num; i++) {
                 ImGui::TableNextRow();
                 ImGui::TableSetColumnIndex(0);
-                ImGui::Text("%-8d", i);
+                selected_port = i;
+                ImGui::PushID(i);
+                ImGui::SetNextItemWidth(50.f * emuenv.dpi_scale);
+                if (ImGui::Combo("##swap_port", &selected_port, port_names, ctrl.controllers_num))
+                    swap_controller_ports(ctrl, i + 1, selected_port + 1);
+                ImGui::PopID();
+                ImGui::TableSetColumnIndex(1);
                 ImGui::TableSetColumnIndex(1);
                 if (ImGui::Button(ctrl.controllers_name[i]))
                     rebinds_is_open = true;
@@ -329,8 +372,7 @@ void draw_controllers_dialog(GuiState &gui, EmuEnvState &emuenv) {
                                 color.clear();
                             set_led_color(default_color);
                         }
-                        if (ImGui::IsItemHovered())
-                            ImGui::SetTooltip("%s", lang["use_custom_color_description"].c_str());
+                        SetTooltipEx(lang["use_custom_color_description"].c_str());
                         if (has_custom_color) {
                             ImGui::Spacing();
                             if (ImGui::BeginTable("setColor", 3, ImGuiTableFlags_NoSavedSettings | ImGuiTableFlags_BordersInnerV)) {
@@ -366,11 +408,11 @@ void draw_controllers_dialog(GuiState &gui, EmuEnvState &emuenv) {
                     if (ImGui::Button(common["close"].c_str(), BUTTON_SIZE))
                         rebinds_is_open = false;
 
-#ifdef ANDROID
-                    ImGui::ScrollWhenDragging(); // because only in Android was hard to press scroll slider
-#endif
+                    ImGui::ScrollWhenDragging();
                     ImGui::End();
                 }
+                ImGui::TableSetColumnIndex(2);
+                ImGui::Text("%s", ctrl.controllers_has_motion_support[i] ? common["yes"].c_str() : common["no"].c_str());
             }
             ImGui::EndTable();
         }
@@ -378,9 +420,16 @@ void draw_controllers_dialog(GuiState &gui, EmuEnvState &emuenv) {
         ImGui::TextColored(GUI_COLOR_TEXT_MENUBAR, "%s", lang["not_connected"].c_str());
 
     if (emuenv.ctrl.has_motion_support) {
+        auto &emulator = gui.lang.settings_dialog.emulator;
         ImGui::Spacing();
+        if (ImGui::Checkbox(lang["motion"].c_str(), &emuenv.cfg.disable_motion))
+        config::serialize_config(emuenv.cfg, emuenv.cfg.config_path);
+        if(emuenv.cfg.disable_motion){
+           if(ImGui::Checkbox(emulator["invert_gyro"].c_str(), &emuenv.cfg.invert_gyro))
+               config::serialize_config(emuenv.cfg, emuenv.cfg.config_path);
+           SetTooltipEx(emulator["invert_gyro_description"].c_str());
+        }
         ImGui::PushTextWrapPos(ImGui::GetWindowWidth() - (ImGui::GetStyle().WindowPadding.x * 2.f));
-        ImGui::TextColored(GUI_COLOR_TEXT_TITLE, "%s", lang["motion_support"].c_str());
         ImGui::PopTextWrapPos();
     } else if (emuenv.motion.has_device_motion_support){
         ImGui::Spacing();

--- a/vita3k/gui/src/controls_dialog.cpp
+++ b/vita3k/gui/src/controls_dialog.cpp
@@ -119,8 +119,10 @@ void draw_controls_dialog(GuiState &gui, EmuEnvState &emuenv) {
     static bool overlay_editing = false;
 
     const ImVec2 display_size(emuenv.viewport_size.x, emuenv.viewport_size.y);
+    const ImVec2 center_pos = ImGui::GetMainViewport()->GetCenter(); // Always center this window when appearing
+    const auto BUTTON_SIZE = ImVec2(120.f * emuenv.dpi_scale, 0.f);
     const auto RES_SCALE = ImVec2(display_size.x / emuenv.res_width_dpi_scale, display_size.y / emuenv.res_height_dpi_scale);
-    ImGui::SetNextWindowPos(ImVec2(display_size.x / 2.f, display_size.y / 2.f), ImGuiCond_Always, ImVec2(0.5f, 0.5f));
+    ImGui::SetNextWindowPos(center_pos, ImGuiCond_Always, ImVec2(0.5f, 0.5f));
     ImGui::Begin("Overlay", &gui.controls_menu.controls_dialog, ImGuiWindowFlags_AlwaysAutoResize);
     ImGui::SetWindowFontScale(RES_SCALE.x);
 
@@ -139,6 +141,7 @@ void draw_controls_dialog(GuiState &gui, EmuEnvState &emuenv) {
         config::serialize_config(emuenv.cfg, emuenv.cfg.config_path);
 
     const char *overlay_edit_text = overlay_editing ? "Hide Gamepad Overlay" : "Modify Gamepad Overlay";
+    ImGui::SetCursorPosX((ImGui::GetWindowWidth() / 2.f) - (gmpd / 2.f)); // recenter button
     if (ImGui::Button(overlay_edit_text)) {
         overlay_editing = !overlay_editing;
         set_controller_overlay_state(overlay_editing ? get_overlay_display_mask(emuenv.cfg) : 0, overlay_editing);
@@ -153,6 +156,7 @@ void draw_controls_dialog(GuiState &gui, EmuEnvState &emuenv) {
         set_controller_overlay_opacity(emuenv.cfg.overlay_opacity);
         config::serialize_config(emuenv.cfg, emuenv.cfg.config_path);
     }
+    ImGui::SetCursorPosX((ImGui::GetWindowWidth() / 2.f) - (gmpd / 2.f));
     if (overlay_editing && ImGui::Button("Reset Gamepad")) {
         set_controller_overlay_state(get_overlay_display_mask(emuenv.cfg), true, true);
         emuenv.cfg.overlay_scale = 1.0f;
@@ -169,6 +173,14 @@ void draw_controls_dialog(GuiState &gui, EmuEnvState &emuenv) {
     }
     ImGui::Text("L2/R2 triggers will be displayed only if PSTV mode is enabled.");
 
+    auto &common = emuenv.common_dialog.lang.common;
+    ImGui::SetCursorPosX((ImGui::GetWindowSize().x / 2.f) - (BUTTON_SIZE.x / 2.f));
+    if (ImGui::Button(common["close"].c_str(), BUTTON_SIZE)){
+        overlay_editing = false;
+        set_controller_overlay_state(0);
+        gui.controls_menu.controls_dialog = false;
+    }
+    ImGui::ScrollWhenDragging();
     ImGui::End();
 }
 

--- a/vita3k/gui/src/controls_dialog.cpp
+++ b/vita3k/gui/src/controls_dialog.cpp
@@ -167,11 +167,24 @@ void draw_controls_dialog(GuiState &gui, EmuEnvState &emuenv) {
         set_controller_overlay_state(get_overlay_display_mask(emuenv.cfg), true, true);
         emuenv.cfg.overlay_scale = 1.0f;
         emuenv.cfg.overlay_scale_joystick = 1.0f;
-        emuenv.cfg.overlay_opacity = 100;
+        emuenv.cfg.overlay_opacity = 80;
         set_controller_overlay_scale(emuenv.cfg.overlay_scale, emuenv.cfg.overlay_scale_joystick);
         set_controller_overlay_opacity(emuenv.cfg.overlay_opacity);
         config::serialize_config(emuenv.cfg, emuenv.cfg.config_path);
     }
+    ImGui::Spacing();
+    ImGui::Separator();
+
+    if(emuenv.cfg.enable_gamepad_overlay){
+        auto &emulator = gui.lang.settings_dialog.emulator;
+        ImGui::Checkbox(emulator["sensor_disable"].c_str(), &emuenv.cfg.disable_motion);
+        SetTooltipEx(emulator["sensors_description"].c_str());
+        if (!emuenv.cfg.disable_motion){
+            ImGui::Checkbox(emulator["invert_gyro"].c_str(), &emuenv.cfg.invert_gyro);
+            SetTooltipEx(emulator["invert_gyro_description"].c_str());
+        }
+    }
+    
     ImGui::Spacing();
     ImGui::Separator();
     if(emuenv.cfg.enable_gamepad_overlay && ImGui::Checkbox("Show front/back touchscreen switch button.", &emuenv.cfg.overlay_show_touch_switch)){

--- a/vita3k/gui/src/controls_dialog.cpp
+++ b/vita3k/gui/src/controls_dialog.cpp
@@ -147,21 +147,23 @@ void draw_controls_dialog(GuiState &gui, EmuEnvState &emuenv) {
         set_controller_overlay_state(overlay_editing ? get_overlay_display_mask(emuenv.cfg) : 0, overlay_editing);
     }
     ImGui::Spacing();
-    if (ImGui::SliderFloat("Overlay scale", &emuenv.cfg.overlay_scale, 0.25f, 4.0f, "%.3f", ImGuiSliderFlags_NoInput | ImGuiSliderFlags_NoRoundToFormat | ImGuiSliderFlags_Logarithmic)) {
-        set_controller_overlay_scale(emuenv.cfg.overlay_scale, emuenv.cfg.overlay_scale_joystick);
-        config::serialize_config(emuenv.cfg, emuenv.cfg.config_path);
+    if(emuenv.cfg.enable_gamepad_overlay){
+       if (ImGui::SliderFloat("Overlay scale", &emuenv.cfg.overlay_scale, 0.25f, 4.0f, "%.3f", ImGuiSliderFlags_NoInput | ImGuiSliderFlags_NoRoundToFormat | ImGuiSliderFlags_Logarithmic)) {
+           set_controller_overlay_scale(emuenv.cfg.overlay_scale, emuenv.cfg.overlay_scale_joystick);
+           config::serialize_config(emuenv.cfg, emuenv.cfg.config_path);
+       }
+       ImGui::Spacing();
+       if (ImGui::SliderFloat("Overlay scale joystick", &emuenv.cfg.overlay_scale_joystick, 0.25f, 4.0f, "%.3f", ImGuiSliderFlags_NoInput | ImGuiSliderFlags_NoRoundToFormat | ImGuiSliderFlags_Logarithmic)) {
+           set_controller_overlay_scale(emuenv.cfg.overlay_scale, emuenv.cfg.overlay_scale_joystick);
+           config::serialize_config(emuenv.cfg, emuenv.cfg.config_path);
+       }
+       ImGui::Spacing();
+       if (ImGui::SliderInt("Overlay opacity", &emuenv.cfg.overlay_opacity, 0, 100, "%d%%")) {
+           set_controller_overlay_opacity(emuenv.cfg.overlay_opacity);
+           config::serialize_config(emuenv.cfg, emuenv.cfg.config_path);
+       }
+       ImGui::Spacing();
     }
-    ImGui::Spacing();
-    if (ImGui::SliderFloat("Overlay scale joystick", &emuenv.cfg.overlay_scale_joystick, 0.25f, 4.0f, "%.3f", ImGuiSliderFlags_NoInput | ImGuiSliderFlags_NoRoundToFormat | ImGuiSliderFlags_Logarithmic)) {
-        set_controller_overlay_scale(emuenv.cfg.overlay_scale, emuenv.cfg.overlay_scale_joystick);
-        config::serialize_config(emuenv.cfg, emuenv.cfg.config_path);
-    }
-    ImGui::Spacing();
-    if (ImGui::SliderInt("Overlay opacity", &emuenv.cfg.overlay_opacity, 0, 100, "%d%%")) {
-        set_controller_overlay_opacity(emuenv.cfg.overlay_opacity);
-        config::serialize_config(emuenv.cfg, emuenv.cfg.config_path);
-    }
-    ImGui::Spacing();
     ImGui::SetCursorPosX((ImGui::GetWindowWidth() / 2.f) - (gmpd / 2.f));
     if (overlay_editing && ImGui::Button("Reset Gamepad")) {
         set_controller_overlay_state(get_overlay_display_mask(emuenv.cfg), true, true);

--- a/vita3k/gui/src/controls_dialog.cpp
+++ b/vita3k/gui/src/controls_dialog.cpp
@@ -177,9 +177,9 @@ void draw_controls_dialog(GuiState &gui, EmuEnvState &emuenv) {
     ImGui::Spacing();
     ImGui::Separator();
 
+    auto &emulator = gui.lang.settings_dialog.emulator;
     if(emuenv.cfg.enable_gamepad_overlay){
-        auto &emulator = gui.lang.settings_dialog.emulator;
-        ImGui::Checkbox(emulator["sensor_disable"].c_str(), &emuenv.cfg.disable_motion);
+          ImGui::Checkbox(emulator["sensor_disable"].c_str(), &emuenv.cfg.disable_motion);
         if (!emuenv.cfg.disable_motion){
             ImGui::Checkbox(emulator["invert_gyro"].c_str(), &emuenv.cfg.invert_gyro);
             SetTooltipEx(emulator["invert_gyro_description"].c_str());

--- a/vita3k/gui/src/controls_dialog.cpp
+++ b/vita3k/gui/src/controls_dialog.cpp
@@ -147,7 +147,7 @@ void draw_controls_dialog(GuiState &gui, EmuEnvState &emuenv) {
         set_controller_overlay_state(overlay_editing ? get_overlay_display_mask(emuenv.cfg) : 0, overlay_editing);
     }
     ImGui::Spacing();
-    if(emuenv.cfg.enable_gamepad_overlay){
+    if(overlay_editing){
        if (ImGui::SliderFloat("Overlay scale", &emuenv.cfg.overlay_scale, 0.25f, 4.0f, "%.3f", ImGuiSliderFlags_NoInput | ImGuiSliderFlags_NoRoundToFormat | ImGuiSliderFlags_Logarithmic)) {
            set_controller_overlay_scale(emuenv.cfg.overlay_scale, emuenv.cfg.overlay_scale_joystick);
            config::serialize_config(emuenv.cfg, emuenv.cfg.config_path);
@@ -180,12 +180,12 @@ void draw_controls_dialog(GuiState &gui, EmuEnvState &emuenv) {
     if(emuenv.cfg.enable_gamepad_overlay){
         auto &emulator = gui.lang.settings_dialog.emulator;
         ImGui::Checkbox(emulator["sensor_disable"].c_str(), &emuenv.cfg.disable_motion);
-        SetTooltipEx(emulator["sensors_description"].c_str());
         if (!emuenv.cfg.disable_motion){
             ImGui::Checkbox(emulator["invert_gyro"].c_str(), &emuenv.cfg.invert_gyro);
             SetTooltipEx(emulator["invert_gyro_description"].c_str());
         }
     }
+    SetTooltipEx(emulator["sensors_description"].c_str());
     
     ImGui::Spacing();
     ImGui::Separator();

--- a/vita3k/gui/src/gui.cpp
+++ b/vita3k/gui/src/gui.cpp
@@ -761,7 +761,7 @@ void init(GuiState &gui, EmuEnvState &emuenv) {
 
 #ifdef ANDROID
     // must be called once for the java side to get the scale
-    set_controller_overlay_scale(emuenv.cfg.overlay_scale);
+    set_controller_overlay_scale(emuenv.cfg.overlay_scale, emuenv.cfg.overlay_scale_joystick);
     set_controller_overlay_opacity(emuenv.cfg.overlay_opacity);
 #endif
 }

--- a/vita3k/gui/src/gui.cpp
+++ b/vita3k/gui/src/gui.cpp
@@ -908,6 +908,17 @@ void draw_ui(GuiState &gui, EmuEnvState &emuenv) {
     ImGui::PopFont();
 }
 
+void SetTooltipEx(const char *tooltip) {
+    if (ImGui::IsItemHovered()) {
+        if (!ImGui::BeginTooltip())
+            return;
+        ImGui::PushTextWrapPos(ImGui::GetIO().DisplaySize.x - ImGui::GetStyle().WindowPadding.x * 2);
+        ImGui::Text("%s", tooltip);
+        ImGui::PopTextWrapPos();
+        ImGui::EndTooltip();
+    }
+}
+
 } // namespace gui
 
 namespace ImGui {

--- a/vita3k/gui/src/initial_setup.cpp
+++ b/vita3k/gui/src/initial_setup.cpp
@@ -105,7 +105,7 @@ void draw_initial_setup(GuiState &gui, EmuEnvState &emuenv) {
     ImGui::SetCursorPosY(94.f * SCALE.y);
     ImGui::Separator();
 #ifdef ANDROID
-        const char* path_warning = "Using a different path requires additional permissions";
+        constexpr char path_warning[] = "Using a different path requires additional permissions";
 #endif
     switch (setup) {
     case SELECT_LANGUAGE:

--- a/vita3k/gui/src/live_area.cpp
+++ b/vita3k/gui/src/live_area.cpp
@@ -1062,7 +1062,7 @@ void draw_live_area_screen(GuiState &gui, EmuEnvState &emuenv) {
     const auto SELECT_SIZE = ImVec2(GATE_SIZE.x - (10.f * SCALE.x), GATE_SIZE.y - (5.f * SCALE.y));
     const auto SELECT_POS = ImVec2(GATE_POS.x + (5.f * SCALE.y), GATE_POS.y + (2.f * SCALE.y));
 
-    const auto BUTTON_SIZE = ImVec2(72.f * SCALE.x, 30.f * SCALE.y);
+    const auto BUTTON_SIZE = ImVec2(80.f * SCALE.x, 55.f * SCALE.y);
 
     if (gui.live_area_contents[app_path].contains("gate")) {
         ImGui::SetCursorPos(GATE_POS);

--- a/vita3k/gui/src/main_menubar.cpp
+++ b/vita3k/gui/src/main_menubar.cpp
@@ -172,7 +172,9 @@ void draw_main_menu_bar(GuiState &gui, EmuEnvState &emuenv) {
 
         draw_file_menu(gui, emuenv);
         draw_emulation_menu(gui, emuenv);
-        draw_debug_menu(gui, gui.debug_menu);
+        if(emuenv.cfg.debug_menu)
+            draw_debug_menu(gui, gui.debug_menu);
+        
         draw_config_menu(gui, emuenv);
         draw_controls_menu(gui);
         draw_help_menu(gui);

--- a/vita3k/gui/src/private.h
+++ b/vita3k/gui/src/private.h
@@ -77,4 +77,6 @@ void draw_user_management(GuiState &gui, EmuEnvState &emuenv);
 
 void reevaluate_code(GuiState &gui, EmuEnvState &emuenv);
 
+void SetTooltipEx(const char *tooltip);
+
 } // namespace gui

--- a/vita3k/gui/src/settings_dialog.cpp
+++ b/vita3k/gui/src/settings_dialog.cpp
@@ -1353,6 +1353,8 @@ void draw_settings_dialog(GuiState &gui, EmuEnvState &emuenv) {
                 ImGui::SetTooltip("%s", lang.debug["validation_layer_description"].c_str());
         }
         ImGui::Spacing();
+        ImGui::Checkbox(lang.debug["debug_menu"].c_str(), &emuenv.cfg.debug_menu);
+        ImGui::Spacing();
         if (ImGui::Button(emuenv.kernel.debugger.watch_code ? lang.debug["unwatch_code"].c_str() : lang.debug["watch_code"].c_str())) {
             emuenv.kernel.debugger.watch_code = !emuenv.kernel.debugger.watch_code;
             emuenv.kernel.debugger.update_watches();

--- a/vita3k/kernel/include/kernel/types.h
+++ b/vita3k/kernel/include/kernel/types.h
@@ -548,6 +548,22 @@ enum SceSysmoduleInternalModuleId : uint32_t {
     SCE_SYSMODULE_INTERNAL_LOCATION_FACTORY = 0x80000029 //!< Location Factory module
 };
 
+// Indexes in thread local storage (TLS) for system data. It is used mostly by libkernel.
+enum TlsItems {
+    TLS_PROCESS_ID = 0,
+    TLS_THREAD_ID = 1,
+    TLS_SP_TOP = 2,
+    TLS_SP_BOTTOM = 3,
+    TLS_VFP_EXCEPTION = 4,
+    TLS_RESERVED_5,
+    TLS_RESERVED_6, // libc reserved longjump addr
+    TLS_RESERVED_7, // libc reserved some memory address mask
+    TLS_CURRENT_PRIORITY = 8,
+    TLS_CPU_AFFINITY_MASK = 9,
+    TLS_NET_ERRNO = 0x40,
+    TLS_LIBC_ERRNO = 0x88,
+};
+
 struct SceSysmoduleOpt {
     int flags;
     Ptr<int> result;

--- a/vita3k/kernel/src/thread.cpp
+++ b/vita3k/kernel/src/thread.cpp
@@ -71,7 +71,7 @@ int ThreadState::init(const char *name, Ptr<const void> entry_point, int init_pr
     start_tick = rtc_get_ticks(kernel.base_tick.tick);
     last_vblank_waited = 0;
 
-    cpu = init_cpu(kernel.cpu_backend, kernel.cpu_opt, id, static_cast<std::size_t>(core_num), mem, kernel.cpu_protocol.get());
+    cpu = init_cpu(kernel.cpu_backend, kernel.cpu_opt, kernel.cpu_unsafe, id, static_cast<std::size_t>(core_num), mem, kernel.cpu_protocol.get());
     if (!cpu) {
         return SCE_KERNEL_ERROR_ERROR;
     }
@@ -92,13 +92,18 @@ int ThreadState::init(const char *name, Ptr<const void> entry_point, int init_pr
     const Ptr<uint8_t> base_tls_ptr = tls.get_ptr<uint8_t>();
     memset(base_tls_ptr.get(mem), 0, tls_size);
 
+    int *tls_array = tls.get_ptr<int>().get(mem);
+    tls_array[TLS_PROCESS_ID] = 1; // stubbed. unused
+    tls_array[TLS_THREAD_ID] = id;
+    tls_array[TLS_SP_TOP] = stack.get();
+    tls_array[TLS_SP_BOTTOM] = stack.get() + stack_size;
+    tls_array[TLS_CURRENT_PRIORITY] = priority;
+    tls_array[TLS_CPU_AFFINITY_MASK] = affinity_mask;
+    const Ptr<uint8_t> user_tls_ptr = base_tls_ptr + KERNEL_TLS_SIZE;
+    write_tpidruro(*cpu, user_tls_ptr.address());
     if (kernel.tls_address) {
-        const Ptr<uint8_t> user_tls_ptr = base_tls_ptr + KERNEL_TLS_SIZE;
-        write_tpidruro(*cpu, user_tls_ptr.address());
         assert(kernel.tls_psize <= kernel.tls_msize);
         memcpy(user_tls_ptr.get(mem), kernel.tls_address.get(mem), kernel.tls_psize);
-    } else {
-        write_tpidruro(*cpu, 0);
     }
 
     CPUContext ctx;

--- a/vita3k/kernel/src/thread.cpp
+++ b/vita3k/kernel/src/thread.cpp
@@ -71,7 +71,7 @@ int ThreadState::init(const char *name, Ptr<const void> entry_point, int init_pr
     start_tick = rtc_get_ticks(kernel.base_tick.tick);
     last_vblank_waited = 0;
 
-    cpu = init_cpu(kernel.cpu_backend, kernel.cpu_opt, kernel.cpu_unsafe, id, static_cast<std::size_t>(core_num), mem, kernel.cpu_protocol.get());
+    cpu = init_cpu(kernel.cpu_backend, kernel.cpu_opt, id, static_cast<std::size_t>(core_num), mem, kernel.cpu_protocol.get());
     if (!cpu) {
         return SCE_KERNEL_ERROR_ERROR;
     }

--- a/vita3k/lang/include/lang/state.h
+++ b/vita3k/lang/include/lang/state.h
@@ -715,6 +715,7 @@ struct LangState {
             { "dump_elfs_description", "Dump loaded code as ELFs." },
             { "validation_layer", "Validation Layer (Reboot required)" },
             { "validation_layer_description", "Enable Vulkan validation layer." },
+            { "debug_menu", "Enable debug menu in menubar" },
             { "unwatch_code", "Unwatch Code" },
             { "watch_code", "Watch Code" },
             { "unwatch_memory", "Unwatch Memory" },

--- a/vita3k/lang/include/lang/state.h
+++ b/vita3k/lang/include/lang/state.h
@@ -683,7 +683,12 @@ struct LangState {
             { "delay_background", "Delay for backgrounds" },
             { "select_delay_background", "Select the delay (in seconds) before changing backgrounds." },
             { "delay_start", "Delay for start screen" },
-            { "select_delay_start", "Select the delay (in seconds) before returning to the start screen." }
+            { "select_delay_start", "Select the delay (in seconds) before returning to the start screen." },
+            { "sensor_enable", "Disable HW acceleration and gyroscope" },
+            { "sensors_description", "Disable or enable built-in sensor" },
+            { "invert_gyro", "Invert gyroscope sensor input" },
+            { "invert_gyro_description", "Change logic of gyroscope sensor to inverse type" }
+            
         };
         std::map<std::string, std::string> network = {
             { "title", "Network" },

--- a/vita3k/lang/include/lang/state.h
+++ b/vita3k/lang/include/lang/state.h
@@ -645,7 +645,11 @@ struct LangState {
             { "reset_emu_path", "Reset Emulator Path" },
             { "reset_emu_path_description", "Reset Vita3K emulator path to the default.\nYou will need to move your old folder to the new location manually." },
             { "custom_config_settings", "Custom Config Settings" },
-            { "clear_custom_config", "Clear Custom Config" }
+            { "clear_custom_config", "Clear Custom Config" },
+            { "sensor_disable", "Disable HW acceleration and gyroscope" },
+            { "sensors_description", "Disable or enable built-in sensor" },
+            { "invert_gyro", "Invert gyroscope sensor motion" },
+            { "invert_gyro_description", "Change gyroscope sensor to inverse mode" }
         };
         std::map<std::string, std::string> gui = {
             { "title", "GUI" },
@@ -683,12 +687,7 @@ struct LangState {
             { "delay_background", "Delay for backgrounds" },
             { "select_delay_background", "Select the delay (in seconds) before changing backgrounds." },
             { "delay_start", "Delay for start screen" },
-            { "select_delay_start", "Select the delay (in seconds) before returning to the start screen." },
-            { "sensor_enable", "Disable HW acceleration and gyroscope" },
-            { "sensors_description", "Disable or enable built-in sensor" },
-            { "invert_gyro", "Invert gyroscope sensor input" },
-            { "invert_gyro_description", "Change logic of gyroscope sensor to inverse type" }
-            
+            { "select_delay_start", "Select the delay (in seconds) before returning to the start screen." }
         };
         std::map<std::string, std::string> network = {
             { "title", "Network" },

--- a/vita3k/modules/SceDriverUser/SceMotion.cpp
+++ b/vita3k/modules/SceDriverUser/SceMotion.cpp
@@ -82,27 +82,34 @@ EXPORT(int, sceMotionGetSensorState, SceMotionSensorState *sensorState, int numR
     if (!sensorState)
         return RET_ERROR(SCE_MOTION_ERROR_NULL_PARAMETER);
 
-    if (emuenv.ctrl.has_motion_support || emuenv.motion.has_device_motion_support) {
-        std::lock_guard<std::mutex> guard(emuenv.motion.mutex);
-        sensorState->accelerometer = get_acceleration(emuenv.motion);
-        sensorState->gyro = get_gyroscope(emuenv.motion);
-
-        sensorState->timestamp = emuenv.motion.last_accel_timestamp;
-        sensorState->counter = emuenv.motion.last_counter;
-        sensorState->hostTimestamp = sensorState->timestamp;
-        sensorState->dataInfo = 0;
-    } else {
-        // some default values
-        memset(sensorState, 0, sizeof(*sensorState));
-        sensorState->accelerometer.z = -1.0;
-
-        std::chrono::time_point<std::chrono::steady_clock> ts = std::chrono::steady_clock::now();
-        uint64_t timestamp = std::chrono::duration_cast<std::chrono::microseconds>(ts.time_since_epoch()).count();
-        sensorState->timestamp = timestamp;
-        sensorState->hostTimestamp = timestamp;
-
-        sensorState->counter = emuenv.motion.last_counter++;
-    }
+        if (emuenv.ctrl.has_motion_support || emuenv.motion.has_device_motion_support && !emuenv.cfg.disable_motion) {
+            std::lock_guard<std::mutex> guard(emuenv.motion.mutex);
+            sensorState->accelerometer = get_acceleration(emuenv.motion);
+            sensorState->gyro = get_gyroscope(emuenv.motion);
+            if(emuenv.cfg.invert_gyro){
+               sensorState->gyro.x = sensorState->gyro.x * -1;
+               sensorState->gyro.y = sensorState->gyro.y * -1;
+               sensorState->gyro.z = sensorState->gyro.z * -1;
+            }
+            sensorState->timestamp = emuenv.motion.last_accel_timestamp;
+            sensorState->counter = emuenv.motion.last_counter;
+            sensorState->hostTimestamp = sensorState->timestamp;
+            sensorState->dataInfo = 0;
+        } else {
+            // some default values
+            memset(sensorState, 0, sizeof(*sensorState));
+            sensorState->accelerometer.z = -1.0;
+            sensorState->accelerometer.x = 0;
+            sensorState->accelerometer.y = 0;
+            sensorState->gyro = {0,0,0};
+            
+            std::chrono::time_point<std::chrono::steady_clock> ts = std::chrono::steady_clock::now();
+            uint64_t timestamp = std::chrono::duration_cast<std::chrono::microseconds>(ts.time_since_epoch()).count();
+            sensorState->timestamp = timestamp;
+            sensorState->hostTimestamp = timestamp;
+    
+            sensorState->counter = emuenv.motion.last_counter++;
+        }
 
     for (int i = 1; i < numRecords; i++)
         sensorState[i] = sensorState[0];
@@ -115,43 +122,50 @@ EXPORT(int, sceMotionGetState, SceMotionState *motionState) {
     if (!motionState)
         return RET_ERROR(SCE_MOTION_ERROR_NULL_PARAMETER);
 
-    if (emuenv.ctrl.has_motion_support || emuenv.motion.has_device_motion_support) {
-        std::lock_guard<std::mutex> guard(emuenv.motion.mutex);
-        motionState->timestamp = emuenv.motion.last_accel_timestamp;
-
-        motionState->acceleration = get_acceleration(emuenv.motion);
-        motionState->angularVelocity = get_gyroscope(emuenv.motion);
-
-        Util::Quaternion dev_quat = get_orientation(emuenv.motion);
-
-        static_assert(sizeof(motionState->deviceQuat) == sizeof(dev_quat));
-        memcpy(&motionState->deviceQuat, &dev_quat, sizeof(motionState->deviceQuat));
-
-        *reinterpret_cast<decltype(dev_quat.ToMatrix()) *>(&motionState->rotationMatrix) = dev_quat.ToMatrix();
-        // not right, but we can't do better without a magnetometer
-        memcpy(&motionState->nedMatrix, &motionState->rotationMatrix, sizeof(motionState->nedMatrix));
-
-        motionState->hostTimestamp = motionState->timestamp;
-        // set it as unstable because we don't have one
-        motionState->magnFieldStability = SCE_MOTION_MAGNETIC_FIELD_UNSTABLE;
-        motionState->dataInfo = 0;
-    } else {
-        // put some default values
-        memset(motionState, 0, sizeof(SceMotionState));
-
-        std::chrono::time_point<std::chrono::steady_clock> ts = std::chrono::steady_clock::now();
-        uint64_t timestamp = std::chrono::duration_cast<std::chrono::microseconds>(ts.time_since_epoch()).count();
-        motionState->timestamp = timestamp;
-        motionState->hostTimestamp = timestamp;
-
-        motionState->acceleration.z = -1.0;
-        motionState->deviceQuat.z = 1;
-        for (int i = 0; i < 4; i++) {
-            // identity matrices
-            reinterpret_cast<float *>(&motionState->rotationMatrix.x.x)[i * 4 + i] = 1;
-            reinterpret_cast<float *>(&motionState->nedMatrix.x.x)[i * 4 + i] = 1;
+        if (emuenv.ctrl.has_motion_support || emuenv.motion.has_device_motion_support && !emuenv.cfg.disable_motion) {
+            std::lock_guard<std::mutex> guard(emuenv.motion.mutex);
+            motionState->timestamp = emuenv.motion.last_accel_timestamp;
+    
+            motionState->acceleration = get_acceleration(emuenv.motion);
+            motionState->angularVelocity = get_gyroscope(emuenv.motion);
+            if(emuenv.cfg.invert_gyro){
+               motionState->angularVelocity.x = motionState->angularVelocity.x * -1;
+               motionState->angularVelocity.y = motionState->angularVelocity.y * -1;
+               motionState->angularVelocity.z = motionState->angularVelocity.z * -1;
+            }
+            Util::Quaternion dev_quat = get_orientation(emuenv.motion);
+    
+            static_assert(sizeof(motionState->deviceQuat) == sizeof(dev_quat));
+            memcpy(&motionState->deviceQuat, &dev_quat, sizeof(motionState->deviceQuat));
+    
+            *reinterpret_cast<decltype(dev_quat.ToMatrix()) *>(&motionState->rotationMatrix) = dev_quat.ToMatrix();
+            // not right, but we can't do better without a magnetometer
+            memcpy(&motionState->nedMatrix, &motionState->rotationMatrix, sizeof(motionState->nedMatrix));
+    
+            motionState->hostTimestamp = motionState->timestamp;
+            // set it as unstable because we don't have one
+            motionState->magnFieldStability = SCE_MOTION_MAGNETIC_FIELD_UNSTABLE;
+            motionState->dataInfo = 0;
+        } else {
+            // put some default values
+            memset(motionState, 0, sizeof(SceMotionState));
+    
+            std::chrono::time_point<std::chrono::steady_clock> ts = std::chrono::steady_clock::now();
+            uint64_t timestamp = std::chrono::duration_cast<std::chrono::microseconds>(ts.time_since_epoch()).count();
+            motionState->timestamp = timestamp;
+            motionState->hostTimestamp = timestamp;
+    
+            motionState->acceleration.z = -1.0;
+            motionState->acceleration.y = 0;
+            motionState->acceleration.x = 0;
+            motionState->angularVelocity = {0,0,0};
+            motionState->deviceQuat.z = 1;
+            for (uint8_t i = 0; i < 4; i++) {
+                // identity matrices
+                reinterpret_cast<float *>(&motionState->rotationMatrix.x.x)[i * 4 + i] = 1;
+                reinterpret_cast<float *>(&motionState->nedMatrix.x.x)[i * 4 + i] = 1;
+            }
         }
-    }
 
     return 0;
 }

--- a/vita3k/modules/SceKernelThreadMgr/SceThreadmgr.cpp
+++ b/vita3k/modules/SceKernelThreadMgr/SceThreadmgr.cpp
@@ -249,9 +249,16 @@ EXPORT(int, _sceKernelGetEventInfo) {
     return UNIMPLEMENTED();
 }
 
-EXPORT(int, _sceKernelGetEventPattern) {
-    TRACY_FUNC(_sceKernelGetEventPattern);
-    return UNIMPLEMENTED();
+EXPORT(SceInt32, _sceKernelGetEventPattern, SceUID event_id, SceUInt32 *get_pattern) {
+    TRACY_FUNC(_sceKernelGetEventPattern, event_id, get_pattern);
+    const SimpleEventPtr event = lock_and_find(event_id, emuenv.kernel.simple_events, emuenv.kernel.mutex);
+    if (!event)
+        return RET_ERROR(SCE_KERNEL_ERROR_UNKNOWN_EVENT_ID);
+    if (!get_pattern)
+        return RET_ERROR(SCE_KERNEL_ERROR_ILLEGAL_ADDR);
+
+    *get_pattern = event->pattern;
+    return SCE_KERNEL_OK;
 }
 
 EXPORT(int, _sceKernelGetLwCondInfo) {
@@ -895,6 +902,7 @@ EXPORT(SceInt32, sceKernelChangeThreadCpuAffinityMask, SceUID thid, SceInt32 aff
         return RET_ERROR(SCE_KERNEL_ERROR_ILLEGAL_CPU_AFFINITY_MASK);
 
     thread->affinity_mask = affinity_mask;
+    thread->tls.get_ptr<int>().get(emuenv.mem)[TLS_CPU_AFFINITY_MASK] = affinity_mask;
     return old_affinity;
 }
 
@@ -919,6 +927,7 @@ EXPORT(SceInt32, sceKernelChangeThreadPriority2, SceUID thid, SceInt32 priority)
         return RET_ERROR(SCE_KERNEL_ERROR_ILLEGAL_PRIORITY);
 
     thread->priority = priority;
+    thread->tls.get_ptr<int>().get(emuenv.mem)[TLS_CURRENT_PRIORITY] = priority;
 
     return old_priority;
 }
@@ -934,7 +943,17 @@ EXPORT(SceInt32, sceKernelChangeThreadPriority, SceUID thid, SceInt32 priority) 
 
 EXPORT(int, sceKernelChangeThreadVfpException, SceInt32 clearMask, SceInt32 setMask) {
     TRACY_FUNC(sceKernelChangeThreadVfpException, clearMask, setMask);
-    return UNIMPLEMENTED();
+    if (((clearMask | setMask) & 0xf7ffff60) != 0 || (clearMask & setMask) != 0) {
+        return RET_ERROR(SCE_KERNEL_ERROR_INVALID_ARGUMENT);
+    }
+    const ThreadStatePtr thread = emuenv.kernel.get_thread(thread_id);
+    if (!thread)
+        return RET_ERROR(SCE_KERNEL_ERROR_UNKNOWN_THREAD_ID);
+    int &vfp_exception = thread->tls.get_ptr<int>().get(emuenv.mem)[TLS_VFP_EXCEPTION];
+    int old_exception = vfp_exception;
+    vfp_exception = setMask | (vfp_exception & ~clearMask);
+    STUBBED("");
+    return old_exception;
 }
 
 EXPORT(SceInt32, sceKernelCheckCallback) {

--- a/vita3k/modules/SceKernelThreadMgr/SceThreadmgr.h
+++ b/vita3k/modules/SceKernelThreadMgr/SceThreadmgr.h
@@ -64,6 +64,7 @@ DECL_EXPORT(SceInt32, _sceKernelWaitEventFlagCB, SceUID evfId, SceUInt32 bitPatt
 DECL_EXPORT(SceInt32, _sceKernelWaitSema, SceUID semaId, SceInt32 needCount, SceUInt32 *pTimeout);
 DECL_EXPORT(SceInt32, _sceKernelWaitSemaCB, SceUID semaId, SceInt32 needCount, SceUInt32 *pTimeout);
 DECL_EXPORT(SceInt32, _sceKernelGetEventFlagInfo, SceUID evfId, Ptr<SceKernelEventFlagInfo> pInfo);
+DECL_EXPORT(SceInt32, _sceKernelGetEventPattern, SceUID event_id, SceUInt32 *get_pattern);
 DECL_EXPORT(int, _sceKernelPollEventFlag, SceUID event_id, unsigned int flags, unsigned int wait, unsigned int *outBits);
 DECL_EXPORT(SceInt32, _sceKernelCancelEventFlag, SceUID event_id, SceUInt pattern, SceUInt32 *num_wait_thread);
 DECL_EXPORT(int, _sceKernelCancelSema, SceUID semaId, SceInt32 setCount, SceUInt32 *pNumWaitThreads);

--- a/vita3k/modules/SceLibKernel/SceLibKernel.cpp
+++ b/vita3k/modules/SceLibKernel/SceLibKernel.cpp
@@ -381,7 +381,7 @@ EXPORT(int, sceClibStrlcpyChk) {
 
 EXPORT(int, sceClibStrncasecmp, const char *s1, const char *s2, SceSize len) {
     TRACY_FUNC(sceClibStrncasecmp, s1, s2, len);
-#ifdef WIN32
+#ifdef _WIN32
     return _strnicmp(s1, s2, len);
 #else
     return strncasecmp(s1, s2, len);
@@ -1304,7 +1304,7 @@ EXPORT(SceInt32, sceKernelGetCondInfo, SceUID condId, Ptr<SceKernelCondInfo> pIn
 
 EXPORT(int, sceKernelGetCurrentThreadVfpException) {
     TRACY_FUNC(sceKernelGetCurrentThreadVfpException);
-    return UNIMPLEMENTED();
+    return emuenv.kernel.get_thread(thread_id)->tls.get_ptr<int>().get(emuenv.mem)[TLS_VFP_EXCEPTION];
 }
 
 EXPORT(SceInt32, sceKernelGetEventFlagInfo, SceUID evfId, Ptr<SceKernelEventFlagInfo> pInfo) {
@@ -1317,9 +1317,9 @@ EXPORT(int, sceKernelGetEventInfo) {
     return UNIMPLEMENTED();
 }
 
-EXPORT(int, sceKernelGetEventPattern) {
-    TRACY_FUNC(sceKernelGetEventPattern);
-    return UNIMPLEMENTED();
+EXPORT(SceInt32, sceKernelGetEventPattern, SceUID event_id, SceUInt32 *get_pattern) {
+    TRACY_FUNC(sceKernelGetEventPattern, event_id, get_pattern);
+    return CALL_EXPORT(_sceKernelGetEventPattern, event_id, get_pattern);
 }
 
 EXPORT(int, sceKernelGetLwCondInfo) {

--- a/vita3k/renderer/include/renderer/vulkan/state.h
+++ b/vita3k/renderer/include/renderer/vulkan/state.h
@@ -1,5 +1,5 @@
 // Vita3K emulator project
-// Copyright (C) 2024 Vita3K team
+// Copyright (C) 2025 Vita3K team
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -59,7 +59,7 @@ struct VKState : public renderer::State {
     vk::PhysicalDeviceFeatures physical_device_features;
     vk::PhysicalDeviceMemoryProperties physical_device_memory;
     std::vector<vk::QueueFamilyProperties> physical_device_queue_families;
-
+    vk::Format deep_stencil_use;
     vma::Allocator allocator;
 
     uint32_t general_family_index = 0;

--- a/vita3k/renderer/src/vulkan/creation.cpp
+++ b/vita3k/renderer/src/vulkan/creation.cpp
@@ -1,5 +1,5 @@
 // Vita3K emulator project
-// Copyright (C) 2024 Vita3K team
+// Copyright (C) 2025 Vita3K team
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -152,7 +152,7 @@ VKContext::VKContext(VKState &state, MemState &mem)
 
 VKRenderTarget::VKRenderTarget(VKState &state, const SceGxmRenderTargetParams &params)
     : color(static_cast<uint32_t>(params.width * state.res_multiplier), static_cast<uint32_t>(params.height * state.res_multiplier), vk::Format::eR8G8B8A8Unorm)
-    , depthstencil(static_cast<uint32_t>(params.width * state.res_multiplier), static_cast<uint32_t>(params.height * state.res_multiplier), vk::Format::eD32SfloatS8Uint) {
+    , depthstencil(static_cast<uint32_t>(params.width * state.res_multiplier), static_cast<uint32_t>(params.height * state.res_multiplier), deep_stencil_use) {
     width = static_cast<uint32_t>(params.width * state.res_multiplier);
     height = static_cast<uint32_t>(params.height * state.res_multiplier);
 

--- a/vita3k/renderer/src/vulkan/pipeline_cache.cpp
+++ b/vita3k/renderer/src/vulkan/pipeline_cache.cpp
@@ -1,5 +1,5 @@
 // Vita3K emulator project
-// Copyright (C) 2024 Vita3K team
+// Copyright (C) 2025 Vita3K team
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -518,7 +518,7 @@ vk::RenderPass PipelineCache::retrieve_render_pass(vk::Format format, bool force
     vk::AttachmentLoadOp load_op = force_load ? vk::AttachmentLoadOp::eLoad : vk::AttachmentLoadOp::eClear;
     vk::AttachmentStoreOp store_op = force_store ? vk::AttachmentStoreOp::eStore : vk::AttachmentStoreOp::eDontCare;
     vk::AttachmentDescription ds_attachment{
-        .format = vk::Format::eD32SfloatS8Uint,
+        .format = deep_stencil_use,
         .samples = vk::SampleCountFlagBits::e1,
         .loadOp = load_op,
         .storeOp = store_op,

--- a/vita3k/renderer/src/vulkan/screen_renderer.cpp
+++ b/vita3k/renderer/src/vulkan/screen_renderer.cpp
@@ -1,5 +1,5 @@
 // Vita3K emulator project
-// Copyright (C) 2024 Vita3K team
+// Copyright (C) 2025 Vita3K team
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -64,7 +64,11 @@ bool ScreenRenderer::create(SDL_Window *window) {
 
 bool ScreenRenderer::setup() {
     const auto surface_formats = state.physical_device.getSurfaceFormatsKHR(surface);
+    const vk::FormatProperties d32u8_support = state.physical_device.getFormatProperties(vk::Format::eD32SfloatS8Uint);
+
     bool surface_format_found = false;
+    bool support_d32u8 = static_cast<bool>(d32u8_support.optimalTilingFeatures & vk::FormatFeatureFlagBits::eSampledImageFilterLinear);
+
     for (const auto &format : surface_formats) {
         // actually we don't care that much because we will just be copying what the game rendered
         // rgba8 or bgra8 should be the best as it matches the format output from the vita (we don't care about the swizzle)
@@ -78,6 +82,13 @@ bool ScreenRenderer::setup() {
     if (!surface_format_found)
         surface_format = surface_formats[0];
 
+    if(support_d32u8){
+        LOG_INFO_ONCE("Your device support high deep stencil quality");
+        deep_stencil_use = vk::Format::eD32SfloatS8Uint;
+    }else{
+        deep_stencil_use = vk::Format::eD24UnormS8Uint;
+    }
+        
     // preferred order : mailbox > fifo_relaxed > fifo > whatever
     // the only drawback for mailbox is that it draws more power, so maybe on a portable device use something else
     const auto present_modes = state.physical_device.getSurfacePresentModesKHR(surface);

--- a/vita3k/renderer/src/vulkan/surface_cache.cpp
+++ b/vita3k/renderer/src/vulkan/surface_cache.cpp
@@ -1,5 +1,5 @@
 // Vita3K emulator project
-// Copyright (C) 2024 Vita3K team
+// Copyright (C) 2025 Vita3K team
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -688,7 +688,7 @@ SurfaceRetrieveResult VKSurfaceCache::retrieve_depth_stencil_for_framebuffer(Sce
 
     image.width = width;
     image.height = height;
-    image.format = vk::Format::eD32SfloatS8Uint;
+    image.format = deep_stencil_use;
     image.layout = vkutil::ImageLayout::Undefined;
     image.init_image(vk::ImageUsageFlagBits::eDepthStencilAttachment | vk::ImageUsageFlagBits::eTransferDst | vk::ImageUsageFlagBits::eTransferSrc | vk::ImageUsageFlagBits::eSampled);
 
@@ -838,7 +838,7 @@ std::optional<TextureLookupResult> VKSurfaceCache::retrieve_depth_stencil_as_tex
             vk::ImageViewCreateInfo view_info{
                 .image = cached_info.texture.image,
                 .viewType = vk::ImageViewType::e2D,
-                .format = vk::Format::eD32SfloatS8Uint,
+                .format = deep_stencil_use,
                 .components = {},
                 .subresourceRange = range
             };
@@ -861,7 +861,7 @@ std::optional<TextureLookupResult> VKSurfaceCache::retrieve_depth_stencil_as_tex
         return TextureLookupResult{
             img_view,
             vkutil::ImageLayout::DepthStencilReadOnly,
-            vk::Format::eD32SfloatS8Uint
+            deep_stencil_use
         };
     }
 
@@ -883,7 +883,7 @@ std::optional<TextureLookupResult> VKSurfaceCache::retrieve_depth_stencil_as_tex
         // no compatible read surface found
 
         DepthSurfaceView read_only{
-            .depth_view = vkutil::Image(width, height, vk::Format::eD32SfloatS8Uint),
+            .depth_view = vkutil::Image(width, height, deep_stencil_use),
             .scene_timestamp = 0,
             .delta_col = delta_col_samples,
             .delta_row = delta_row_samples,
@@ -907,7 +907,7 @@ std::optional<TextureLookupResult> VKSurfaceCache::retrieve_depth_stencil_as_tex
         vk::ImageViewCreateInfo view_info{
             .image = read_only.depth_view.image,
             .viewType = vk::ImageViewType::e2D,
-            .format = vk::Format::eD32SfloatS8Uint,
+            .format = deep_stencil_use,
             .components = {},
             .subresourceRange = range
         };

--- a/vita3k/renderer/src/vulkan/texture.cpp
+++ b/vita3k/renderer/src/vulkan/texture.cpp
@@ -299,17 +299,58 @@ static vk::Format linear_to_srgb(const vk::Format format) {
 
 static vk::Format bcn_to_rgba8(const vk::Format format) {
     switch (format) {
+    // https://www.reedbeta.com/blog/understanding-bcn-texture-compression-formats/
+    
+    // BC1
+    case vk::Format::eBc1RgbUnormBlock:
+        return vk::Format::eR8G8B8Unorm;
+    case vk::Format::eBc1RgbSrgbBlock:
+        return vk::Format::eR8G8B8Snorm;
+    case vk::Format::eBc1RgbaUnormBlock:
+        return vk::Format::eR8G8B8A8Unorm;
+    case vk::Format::eBc1RgbaSrgbBlock:
+        return vk::Format::eR8G8B8A8Snorm;
+    
+    // BC2
+    case vk::Format::eBc2UnormBlock:
+        return vk::Format::eR8G8B8A8Unorm;
+    case vk::Format::eBc2SrgbBlock:
+        return vk::Format::eR8G8B8A8Snorm;
+
+    // BC3
+    case vk::Format::eBc3UnormBlock:
+        return vk::Format::eR8G8B8A8Unorm;
+    case vk::Format::eBc3SrgbBlock:
+        return vk::Format::eR8G8B8A8Snorm;
+
+    // BC4
     case vk::Format::eBc4UnormBlock:
         return vk::Format::eR8Unorm;
     case vk::Format::eBc4SnormBlock:
         return vk::Format::eR8Snorm;
+
+    // BC5
     case vk::Format::eBc5UnormBlock:
         return vk::Format::eR8G8Unorm;
     case vk::Format::eBc5SnormBlock:
         return vk::Format::eR8G8Snorm;
-    default:
-        // BC1/2/3
+
+    // BC6
+    case vk::Format::eBc6HUfloatBlock:
+        return vk::Format::eR16G16B16Sfloat;
+    case vk::Format::eBc6HSfloatBlock:
+        return vk::Format::eR16G16B16Sfloat;
+
+    // BC7
+    case vk::Format::eBc7UnormBlock:
+        return vk::Format::eR16G16B16A16Unorm;
+    case vk::Format::eBc7SrgbBlock:
+        return vk::Format::eR16G16B16A16Snorm;
+
+    default:{
+        LOG_ERROR_ONCE("Trying to convert bcn format with non-compatible format {}", vk::to_string(format));
         return vk::Format::eR8G8B8A8Unorm;
+    }
     }
 }
 
@@ -586,7 +627,9 @@ void VKTextureCache::import_configure_impl(SceGxmTextureBaseFormat base_format, 
         state.frame().destroy_queue.add_image(image);
 
     vk::Format vk_format = texture::translate_format(base_format);
-    if (is_srgb)
+    if (is_srgb && !support_dxt)
+        vk_format = bcn_to_rgba8(vk_format); // for mali users
+    else if (is_srgb)
         vk_format = linear_to_srgb(vk_format);
 
     // manually initialize the image

--- a/vita3k/renderer/src/vulkan/texture.cpp
+++ b/vita3k/renderer/src/vulkan/texture.cpp
@@ -305,23 +305,23 @@ static vk::Format bcn_to_rgba8(const vk::Format format) {
     case vk::Format::eBc1RgbUnormBlock:
         return vk::Format::eR8G8B8Unorm;
     case vk::Format::eBc1RgbSrgbBlock:
-        return vk::Format::eR8G8B8Snorm;
+        return vk::Format::eR8G8B8Srgb;
     case vk::Format::eBc1RgbaUnormBlock:
         return vk::Format::eR8G8B8A8Unorm;
     case vk::Format::eBc1RgbaSrgbBlock:
-        return vk::Format::eR8G8B8A8Snorm;
-    
+        return vk::Format::eR8G8B8A8Srgb;
+  
     // BC2
     case vk::Format::eBc2UnormBlock:
         return vk::Format::eR8G8B8A8Unorm;
     case vk::Format::eBc2SrgbBlock:
-        return vk::Format::eR8G8B8A8Snorm;
+        return vk::Format::eR8G8B8A8Srgb;
 
     // BC3
     case vk::Format::eBc3UnormBlock:
         return vk::Format::eR8G8B8A8Unorm;
     case vk::Format::eBc3SrgbBlock:
-        return vk::Format::eR8G8B8A8Snorm;
+        return vk::Format::eR8G8B8A8Srgb;
 
     // BC4
     case vk::Format::eBc4UnormBlock:
@@ -337,7 +337,7 @@ static vk::Format bcn_to_rgba8(const vk::Format format) {
 
     // BC6
     case vk::Format::eBc6HUfloatBlock:
-        return vk::Format::eR16G16B16Sfloat;
+        return vk::Format::eR16G16Sfloat;
     case vk::Format::eBc6HSfloatBlock:
         return vk::Format::eR16G16B16Sfloat;
 
@@ -345,10 +345,10 @@ static vk::Format bcn_to_rgba8(const vk::Format format) {
     case vk::Format::eBc7UnormBlock:
         return vk::Format::eR16G16B16A16Unorm;
     case vk::Format::eBc7SrgbBlock:
-        return vk::Format::eR16G16B16A16Snorm;
+        return vk::Format::eR16G16B16A16Unorm;
 
     default:{
-        LOG_ERROR_ONCE("Trying to convert bcn format with non-compatible format {}", vk::to_string(format));
+        LOG_ERROR("Trying to convert bcn format with non-compatible format: {}", vk::to_string(format));
         return vk::Format::eR8G8B8A8Unorm;
     }
     }

--- a/vita3k/renderer/src/vulkan/texture.cpp
+++ b/vita3k/renderer/src/vulkan/texture.cpp
@@ -385,11 +385,12 @@ void VKTextureCache::configure_texture(const SceGxmTexture &gxm_texture) {
     const uint16_t mip_count = renderer::texture::get_upload_mip(gxm_texture.true_mip_count(), width, height);
 
     vk::Format vk_format = texture::translate_format(base_format);
+    if (gxm_texture.gamma_mode)
+        vk_format = linear_to_srgb(vk_format);
+    
     if (gxm::is_bcn_format(base_format) && !support_dxt)
         // texture will be decompressed
         vk_format = bcn_to_rgba8(vk_format);
-    if (gxm_texture.gamma_mode)
-        vk_format = linear_to_srgb(vk_format);
 
     current_texture->mip_count = mip_count;
     current_texture->is_cube = is_cube;


### PR DESCRIPTION
- Recenter overlay window and button
- Add close button in overlay menu (because [x] too small and sometimes hard to pressed)
- Allow scrolling in controller menu (because i did tried slide scroll slider at right, sometimes work and sometimes undetected because too small)
- hide "debug" in menubar (it useless for end user and configuration button cant be pressed when multiwindows or freewindow mode because freewindows/multiwindow overide it or camera block it) > this one usefull for people have issue with builtin driver (adreno user) because they cant run fullscreen before install driver
- allow resize joystick only instead all button
- allow fallback to default driver in case custom driver broken (adreno only)
- allow performance mode (may fix some device that have issue with locked in small core than big core)
- cutout mode set to "shortEdges" (so it will draw full screen now, no black bar)
- fix shortcut icon issue
- allow ziped sdl2 files to reduce upload size (from ~24mb to 3.8mb)
- add usb  controller support for A14
- fix texture issue (vulkan) in non bcn supported devices
- add invert gyro and enable/disable motion sensors

example preview:
![Screenshot_20241112_022459_Vita3K](https://github.com/user-attachments/assets/5fedddd3-85a8-41b3-aa83-18d89d3abeac)

https://github.com/user-attachments/assets/4c855d95-75c9-4cf1-92db-df9d691dc4ea

![IMG-20240731-WA0000](https://github.com/user-attachments/assets/1a0da624-8df1-449b-a699-017af602f09b)
![IMG-20240731-WA0001](https://github.com/user-attachments/assets/19916ac4-c19a-4118-94c2-c426230efd75)
![IMG-20240731-WA0003](https://github.com/user-attachments/assets/c34e7092-f625-433f-b4b9-3c83a9085956)

https://github.com/user-attachments/assets/5181939e-0594-4760-bd72-e76942a9beb6

